### PR TITLE
feat(auth): Move refresh tokens to separate entity and table

### DIFF
--- a/src/LinkLeaf.Api/Controllers/AuthController.cs
+++ b/src/LinkLeaf.Api/Controllers/AuthController.cs
@@ -1,10 +1,10 @@
-using System.Net;
 using LinkLeaf.Api.DTOs;
 using LinkLeaf.Api.DTOs.Auth;
 using LinkLeaf.Api.Options;
 using LinkLeaf.Api.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using LinkLeaf.Api.Utils;
 
 namespace LinkLeaf.Api.Controllers;
 
@@ -15,22 +15,32 @@ public class AuthController(IAuthService authService, IOptions<JwtOptions> jwtOp
     private readonly IAuthService _authService = authService;
     private readonly int refreshTokenExpirationMinutes = jwtOptions.Value.RefreshTokenExpirationMinutes;
 
+
+
     [HttpPost("register")]
     public async Task<ActionResult<AuthResponseDto>> Register(
         RegisterRequestDto request,
-        [FromHeader(Name = "X-Client")] string? xClient
+        [FromHeader(Name = "X-Client")] string? xClient = ""
     )
     {
         request.Email = request.Email.ToLower();
 
-        // TODO: Make `ModelState` errors consistent with `ApiResponse`
         if (!ModelState.IsValid)
-            return BadRequest(ModelState);
+        {
+            var errors = ControllerUtils.GetModelErrors(ModelState);
+            return BadRequest(ApiResponse<AuthResponseDto>.FailureResponse(
+                code: ApiStatusCode.VALIDATION_ERROR,
+                errors: errors
+            ));
+        }
 
         var result = await _authService.Register(request);
         if (result is null)
             return BadRequest(
-                ApiResponse<AuthResponseDto>.FailureResponse("Email already exists")
+                ApiResponse<AuthResponseDto>.FailureResponse(
+                    code: ApiStatusCode.USER_EXISTS,
+                    message: "Email address already exists"
+                )
             );
 
         var (tokens, user) = result.Value;
@@ -51,19 +61,26 @@ public class AuthController(IAuthService authService, IOptions<JwtOptions> jwtOp
     [HttpPost("login")]
     public async Task<ActionResult<AuthResponseDto>> Login(
         LoginRequestDto request,
-        [FromHeader(Name = "X-Client")] string? xClient
+        [FromHeader(Name = "X-Client")] string? xClient = ""
     )
     {
         request.Email = request.Email.ToLower();
 
-        // TODO: Make `ModelState` errors consistent with `ApiResponse`
         if (!ModelState.IsValid)
-            return BadRequest(ModelState);
+        {
+            var errors = ControllerUtils.GetModelErrors(ModelState);
+            return BadRequest(ApiResponse<AuthResponseDto>.FailureResponse(
+                code: ApiStatusCode.VALIDATION_ERROR,
+                errors: errors
+            ));
+        }
 
         var result = await _authService.Login(request);
         if (result is null)
             return BadRequest(
-                ApiResponse<AuthResponseDto>.FailureResponse("Invalid credentials")
+                ApiResponse<AuthResponseDto>.FailureResponse(
+                    code: ApiStatusCode.INVALID_CREDENTIALS
+                )
             );
 
         var (tokens, user) = result.Value;
@@ -84,17 +101,22 @@ public class AuthController(IAuthService authService, IOptions<JwtOptions> jwtOp
     [HttpPost("refresh-token")]
     public async Task<ActionResult<AuthResponseDto?>> RefreshToken(
         [FromHeader(Name = "X-Refresh-Token")] string? refreshTokenHeader,
-        [FromHeader(Name = "X-Client")] string? xClient
+        [FromHeader(Name = "X-Client")] string? xClient = ""
     )
     {
         Request.Cookies.TryGetValue("refreshToken", out var refreshTokenCookie);
         var token = refreshTokenCookie ?? refreshTokenHeader;
 
         if (token is null)
-            return BadRequest(ApiResponse<AuthResponseDto>.FailureResponse("Invalid refresh token"));
+            return BadRequest(ApiResponse<AuthResponseDto>.FailureResponse(
+                code: ApiStatusCode.TOKEN_INVALID_OR_EXPIRED
+            ));
         var result = await _authService.RefreshTokens(token);
         if (result is null)
-            return BadRequest(ApiResponse<AuthResponseDto>.FailureResponse("Invalid refresh token"));
+            return BadRequest(ApiResponse<AuthResponseDto>.FailureResponse(
+                code: ApiStatusCode.TOKEN_INVALID_OR_EXPIRED,
+                message: "Invalid or expired token"
+            ));
 
         var (tokens, userDto) = result.Value;
 
@@ -111,7 +133,10 @@ public class AuthController(IAuthService authService, IOptions<JwtOptions> jwtOp
         return Ok(ApiResponse<AuthResponseDto>.SuccessResponse(data: response));
     }
 
-    private void SetRefreshTokenCookie(HttpResponse response, string refreshToken)
+    private void SetRefreshTokenCookie(
+        HttpResponse response,
+        string refreshToken
+    )
     {
         response.Cookies.Append("refreshToken", refreshToken, new CookieOptions
         {
@@ -121,5 +146,4 @@ public class AuthController(IAuthService authService, IOptions<JwtOptions> jwtOp
             Expires = DateTime.UtcNow.AddMinutes(refreshTokenExpirationMinutes)
         });
     }
-
 }

--- a/src/LinkLeaf.Api/Controllers/BookmarksController.cs
+++ b/src/LinkLeaf.Api/Controllers/BookmarksController.cs
@@ -7,6 +7,7 @@ using LinkLeaf.Api.DTOs;
 using LinkLeaf.Api.DTOs.Bookmarks;
 using LinkLeaf.Api.Models;
 using LinkLeaf.Api.Services;
+using LinkLeaf.Api.Utils;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
@@ -24,7 +25,14 @@ public class BookmarksController(IBookmarksService bookmarksService) : Controlle
     public async Task<ActionResult<AddBookmarkResponseDto>> AddBookmark(AddBookmarkRequestDto request)
     {
         if (!ModelState.IsValid)
-            return BadRequest(ApiResponse<AddBookmarkResponseDto>.FailureResponse("Invalid bookmark"));
+        {
+            var errors = ControllerUtils.GetModelErrors(ModelState);
+            return BadRequest(ApiResponse<AddBookmarkResponseDto>.FailureResponse(
+                code: ApiStatusCode.VALIDATION_ERROR,
+                errors: errors
+            ));
+        }
+
 
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (userId is null)

--- a/src/LinkLeaf.Api/DTOs/ApiResponse.cs
+++ b/src/LinkLeaf.Api/DTOs/ApiResponse.cs
@@ -1,14 +1,31 @@
+using System.Text.Json.Serialization;
+
 namespace LinkLeaf.Api.DTOs;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ApiStatusCode
+{
+    VALIDATION_ERROR,
+    TOKEN_INVALID_OR_EXPIRED,
+    INVALID_CREDENTIALS,
+    USER_EXISTS
+}
 
 public class ApiResponse<T>
 {
     public bool Success { get; set; }
     public string? Message { get; set; }
     public T? Data { get; set; }
+    public ApiStatusCode Code { get; set; }
+    public Dictionary<string, List<string>>? Errors { get; set; }
 
     public static ApiResponse<T> SuccessResponse(T data, string? message = null) =>
         new() { Success = true, Message = message, Data = data };
 
-    public static ApiResponse<T> FailureResponse(string message) =>
-        new() { Success = false, Message = message };
+    public static ApiResponse<T> FailureResponse(
+        ApiStatusCode code,
+        Dictionary<string, List<string>>? errors = default,
+        string? message = null
+    ) =>
+        new() { Code = code, Success = false, Message = message, Errors = errors };
 }

--- a/src/LinkLeaf.Api/DTOs/Auth/RegisterRequestDto.cs
+++ b/src/LinkLeaf.Api/DTOs/Auth/RegisterRequestDto.cs
@@ -5,6 +5,10 @@ namespace LinkLeaf.Api.DTOs.Auth;
 public class RegisterRequestDto
 {
     [Required]
+    [RegularExpression(
+      @"^[^@\s]+@[^@\s]+\.[^@\s]+$",
+      ErrorMessage = "Email must be in the form user@domain.tld"
+    )]
     [EmailAddress]
     public string Email { get; set; } = string.Empty;
 

--- a/src/LinkLeaf.Api/Data/AppDbContext.cs
+++ b/src/LinkLeaf.Api/Data/AppDbContext.cs
@@ -7,6 +7,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 {
     public DbSet<User> Users { get; set; }
     public DbSet<Bookmark> Bookmarks { get; set; }
+    public DbSet<RefreshToken> RefreshTokens { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -20,6 +21,12 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             .HasOne(b => b.User)
             .WithMany(u => u.Bookmarks)
             .HasForeignKey(b => b.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<RefreshToken>()
+            .HasOne(t => t.User)
+            .WithMany()
+            .HasForeignKey(t => t.UserId)
             .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/src/LinkLeaf.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/LinkLeaf.Api/Extensions/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class ServiceCollectionExtensions
 
 
         services.AddScoped<IUsersRepository, UsersRepository>();
+        services.AddScoped<IRefreshTokensRepository, RefreshTokensRepository>();
         services.AddScoped<IAuthService, AuthService>();
         services.AddScoped<ITokenHasher, TokenHasher>();
         services.AddScoped<IBookmarksRepository, BookmarksRepository>();

--- a/src/LinkLeaf.Api/Migrations/20250527175657_RefreshTokenTable.Designer.cs
+++ b/src/LinkLeaf.Api/Migrations/20250527175657_RefreshTokenTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LinkLeaf.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LinkLeaf.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250527175657_RefreshTokenTable")]
+    partial class RefreshTokenTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/LinkLeaf.Api/Migrations/20250527175657_RefreshTokenTable.cs
+++ b/src/LinkLeaf.Api/Migrations/20250527175657_RefreshTokenTable.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LinkLeaf.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class RefreshTokenTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RefreshToken",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "RefreshTokenExpiration",
+                table: "Users");
+
+            migrationBuilder.CreateTable(
+                name: "RefreshTokens",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Token = table.Column<string>(type: "text", nullable: false),
+                    TokenExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RefreshTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RefreshTokens_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_UserId",
+                table: "RefreshTokens",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RefreshTokens");
+
+            migrationBuilder.AddColumn<string>(
+                name: "RefreshToken",
+                table: "Users",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "RefreshTokenExpiration",
+                table: "Users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}

--- a/src/LinkLeaf.Api/Migrations/20250527185851_RefreshTokensDeleteCascade.Designer.cs
+++ b/src/LinkLeaf.Api/Migrations/20250527185851_RefreshTokensDeleteCascade.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LinkLeaf.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LinkLeaf.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250527185851_RefreshTokensDeleteCascade")]
+    partial class RefreshTokensDeleteCascade
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/LinkLeaf.Api/Migrations/20250527185851_RefreshTokensDeleteCascade.cs
+++ b/src/LinkLeaf.Api/Migrations/20250527185851_RefreshTokensDeleteCascade.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LinkLeaf.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class RefreshTokensDeleteCascade : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/src/LinkLeaf.Api/Models/RefreshToken.cs
+++ b/src/LinkLeaf.Api/Models/RefreshToken.cs
@@ -1,0 +1,11 @@
+namespace LinkLeaf.Api.Models;
+
+public class RefreshToken
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Token { get; set; } = string.Empty;
+    public DateTime TokenExpiresAt { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public Guid UserId { get; set; }
+    public User User { get; set; } = default!;
+}

--- a/src/LinkLeaf.Api/Models/User.cs
+++ b/src/LinkLeaf.Api/Models/User.cs
@@ -7,7 +7,5 @@ public class User
     public string PasswordHash { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-    public string RefreshToken { get; set; } = string.Empty;
-    public DateTime RefreshTokenExpiration { get; set; } = DateTime.UtcNow;
     public List<Bookmark> Bookmarks { get; set; } = new();
 }

--- a/src/LinkLeaf.Api/Repositories/IUsersRepository.cs
+++ b/src/LinkLeaf.Api/Repositories/IUsersRepository.cs
@@ -9,6 +9,4 @@ public interface IUsersRepository
     Task<User?> FindByEmail(string email);
     Task<User?> AddAsync(User user);
     Task RemoveAsync(Guid id);
-    Task UpdateRefreshToken(Guid id, string token, DateTime expirationDate);
-    Task<User?> FindByRefreshToken(string token);
 }

--- a/src/LinkLeaf.Api/Repositories/RefreshTokensRepository.cs
+++ b/src/LinkLeaf.Api/Repositories/RefreshTokensRepository.cs
@@ -25,7 +25,7 @@ public class RefreshTokensRepository(AppDbContext dbContext, IOptions<JwtOptions
         return refreshToken;
     }
 
-    public async Task<RefreshToken?> FindHashedToken(string token)
+    public async Task<RefreshToken?> FindUserByHashedToken(string token)
     {
         var savedToken = await _db.RefreshTokens
             .Include(t => t.User)

--- a/src/LinkLeaf.Api/Repositories/RefreshTokensRepository.cs
+++ b/src/LinkLeaf.Api/Repositories/RefreshTokensRepository.cs
@@ -1,0 +1,35 @@
+using LinkLeaf.Api.Data;
+using LinkLeaf.Api.Models;
+using LinkLeaf.Api.Options;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace LinkLeaf.Api.Services;
+
+public class RefreshTokensRepository(AppDbContext dbContext, IOptions<JwtOptions> jwtOptions) : IRefreshTokensRepository
+{
+    private readonly AppDbContext _db = dbContext;
+    private readonly int tokenExpirationMinutes = jwtOptions.Value.RefreshTokenExpirationMinutes;
+
+    public async Task<RefreshToken?> AddUserRefreshToken(Guid userId, string token)
+    {
+        var refreshToken = new RefreshToken()
+        {
+            Token = token,
+            TokenExpiresAt = DateTime.UtcNow.AddMinutes(tokenExpirationMinutes),
+            UserId = userId,
+            CreatedAt = DateTime.UtcNow
+        };
+        await _db.RefreshTokens.AddAsync(refreshToken);
+        await _db.SaveChangesAsync();
+        return refreshToken;
+    }
+
+    public async Task<RefreshToken?> FindHashedToken(string token)
+    {
+        var savedToken = await _db.RefreshTokens
+            .Include(t => t.User)
+            .FirstOrDefaultAsync(t => t.Token == token);
+        return savedToken;
+    }
+}

--- a/src/LinkLeaf.Api/Repositories/UsersRepository.cs
+++ b/src/LinkLeaf.Api/Repositories/UsersRepository.cs
@@ -41,18 +41,4 @@ public class UsersRepository(AppDbContext dbContext) : IUsersRepository
             await _db.SaveChangesAsync();
         }
     }
-
-    public async Task UpdateRefreshToken(Guid id, string token, DateTime expirationDate)
-    {
-        var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == id);
-        if (user is not null)
-        {
-            user.RefreshToken = token;
-            user.RefreshTokenExpiration = expirationDate;
-            await _db.SaveChangesAsync();
-        }
-    }
-
-    public async Task<User?> FindByRefreshToken(string token) =>
-        await _db.Users.FirstOrDefaultAsync(u => u.RefreshToken == token);
 }

--- a/src/LinkLeaf.Api/Services/AuthService.cs
+++ b/src/LinkLeaf.Api/Services/AuthService.cs
@@ -89,7 +89,7 @@ public class AuthService(
             return null;
 
         var hashedToken = _tokenHasher.Hash(refreshToken);
-        var savedToken = await _refreshTokensRepo.FindHashedToken(hashedToken);
+        var savedToken = await _refreshTokensRepo.FindUserByHashedToken(hashedToken);
         if (savedToken is null)
             return null;
 

--- a/src/LinkLeaf.Api/Services/AuthService.cs
+++ b/src/LinkLeaf.Api/Services/AuthService.cs
@@ -11,6 +11,7 @@ namespace LinkLeaf.Api.Services;
 
 public class AuthService(
     IJwtService tokenService,
+    IRefreshTokensRepository refreshTokensRepository,
     IUsersRepository usersRepository,
     ITokenHasher tokenHasher,
     IOptions<JwtOptions> jwtOptions
@@ -18,6 +19,7 @@ public class AuthService(
 {
     private readonly IJwtService _tokenService = tokenService;
     private readonly IUsersRepository _usersRepo = usersRepository;
+    private readonly IRefreshTokensRepository _refreshTokensRepo = refreshTokensRepository;
     private readonly ITokenHasher _tokenHasher = tokenHasher;
     private readonly int _refreshTokenExpirationMinutes = jwtOptions.Value.RefreshTokenExpirationMinutes;
 
@@ -35,11 +37,7 @@ public class AuthService(
 
         var tokens = GenerateTokens(user);
 
-        await _usersRepo.UpdateRefreshToken(
-            id: user.Id,
-            token: _tokenHasher.Hash(tokens.RefreshToken),
-            expirationDate: DateTime.UtcNow.AddMinutes(_refreshTokenExpirationMinutes)
-        );
+        await _refreshTokensRepo.AddUserRefreshToken(user.Id, _tokenHasher.Hash(tokens.RefreshToken));
 
         return (
             tokens, new UserDto()
@@ -68,12 +66,12 @@ public class AuthService(
         newUser.PasswordHash = hashedPassword;
 
         var tokens = GenerateTokens(newUser);
-        newUser.RefreshToken = _tokenHasher.Hash(tokens.RefreshToken);
-        newUser.RefreshTokenExpiration = DateTime.UtcNow.AddMinutes(_refreshTokenExpirationMinutes);
+        var refreshToken = _tokenHasher.Hash(tokens.RefreshToken);
 
         var user = await _usersRepo.AddAsync(newUser);
         if (user is null)
             return null;
+        await _refreshTokensRepo.AddUserRefreshToken(user.Id, refreshToken);
 
         return (
                 tokens,
@@ -91,23 +89,17 @@ public class AuthService(
             return null;
 
         var hashedToken = _tokenHasher.Hash(refreshToken);
-        var user = await _usersRepo.FindByRefreshToken(hashedToken);
-        if (user is null)
+        var savedToken = await _refreshTokensRepo.FindHashedToken(hashedToken);
+        if (savedToken is null)
             return null;
 
-        if (
-            user.RefreshTokenExpiration < DateTime.UtcNow ||
-            user.RefreshToken != hashedToken
-        )
+        if (savedToken.TokenExpiresAt < DateTime.UtcNow)
             return null;
 
+        var user = savedToken.User;
 
         var tokens = GenerateTokens(user);
-        await _usersRepo.UpdateRefreshToken(
-            id: user.Id,
-            refreshToken = _tokenHasher.Hash(tokens.RefreshToken),
-            expirationDate: DateTime.UtcNow.AddMinutes(_refreshTokenExpirationMinutes)
-        );
+        await _refreshTokensRepo.AddUserRefreshToken(user.Id, _tokenHasher.Hash(tokens.RefreshToken));
 
         return (
             tokens,

--- a/src/LinkLeaf.Api/Services/IRefreshTokensRepository.cs
+++ b/src/LinkLeaf.Api/Services/IRefreshTokensRepository.cs
@@ -5,5 +5,5 @@ namespace LinkLeaf.Api.Services;
 public interface IRefreshTokensRepository
 {
     Task<RefreshToken?> AddUserRefreshToken(Guid userId, string token);
-    Task<RefreshToken?> FindHashedToken(string token);
+    Task<RefreshToken?> FindUserByHashedToken(string token);
 }

--- a/src/LinkLeaf.Api/Services/IRefreshTokensRepository.cs
+++ b/src/LinkLeaf.Api/Services/IRefreshTokensRepository.cs
@@ -1,0 +1,9 @@
+using LinkLeaf.Api.Models;
+
+namespace LinkLeaf.Api.Services;
+
+public interface IRefreshTokensRepository
+{
+    Task<RefreshToken?> AddUserRefreshToken(Guid userId, string token);
+    Task<RefreshToken?> FindHashedToken(string token);
+}

--- a/src/LinkLeaf.Api/Utils/ControllerUtils.cs
+++ b/src/LinkLeaf.Api/Utils/ControllerUtils.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace LinkLeaf.Api.Utils;
+
+public static class ControllerUtils
+{
+    public static Dictionary<string, List<string>> GetModelErrors(ModelStateDictionary modelState)
+    {
+        Dictionary<string, List<string>> errors = [];
+        foreach (var key in modelState.Keys)
+        {
+            var modelStateEntry = modelState[key];
+            if (modelStateEntry?.Errors.Count > 0)
+            {
+                foreach (var error in modelStateEntry.Errors)
+                {
+                    if (!errors.ContainsKey(key))
+                        errors[key] = [];
+                    errors[key].Add(error.ErrorMessage);
+                }
+            }
+        }
+        return errors;
+    }
+}


### PR DESCRIPTION
This PR moves the `RefreshToken` from the `User` model into a separate entity and table in the database, allowing for multiple refresh tokens per user (e.g. different clients).